### PR TITLE
NodeDomain 'close' handler should test for promise before reloading

### DIFF
--- a/lib/NodeDomain.js
+++ b/lib/NodeDomain.js
@@ -76,7 +76,9 @@ define(function (require, exports, module) {
         connection.on("close", function (promise) {
             this.connection.off(domainPrefix);
             this._domainLoaded = false;
-            this._connectionPromise = promise.then(this._load);
+            if (promise) {
+                this._connectionPromise = promise.then(this._load);
+            }
         }.bind(this));
     }
 


### PR DESCRIPTION
If the underlying NodeConnection is explicitly disconnected with `domain.connection.disconnect()`, it sets the _autoReconnect flag to false. Subsequently, "close" is emitted without the associated promise, which then causes the handler in NodeDomain to throw.