### PR TITLE
When creating a new NodeDomain, the domain path is now optional

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "generator-connection",
   "description": "Generator Websocket RPC client",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "authors": [
     "Ian Wehrman <wehrman@adobe.com>",
     "Cory McIlroy <mcilroy@adobe.com>"

--- a/lib/NodeConnection.js
+++ b/lib/NodeConnection.js
@@ -369,6 +369,7 @@ define(function (require, exports, module) {
     NodeConnection.prototype.loadDomains = function (paths, autoReload) {
         var deferred = Promise.defer();
         setDeferredTimeout(deferred, CONNECTION_TIMEOUT);
+
         var pathArray = paths;
         if (!Array.isArray(paths)) {
             pathArray = [paths];
@@ -402,7 +403,7 @@ define(function (require, exports, module) {
         
         return deferred.promise;
     };
-    
+
     /**
      * @private
      * Sends a message over the WebSocket. Automatically JSON.stringifys

--- a/lib/NodeDomain.js
+++ b/lib/NodeDomain.js
@@ -40,7 +40,8 @@ define(function (require, exports, module) {
      * a promise-returning method that can safely be called regardless of the
      * current status of the underlying connection. Example usage:
      * 
-     * var myDomain = new NodeDomain("someDomain", "/path/to/SomeDomainDef.js"),
+     * var getRemotePort = function () { return 59596 };
+     *     myDomain = new NodeDomain("someDomain", getRemotePort, "/path/to/SomeDomainDef.js"),
      *     result = myDomain.exec("someCommand", arg1, arg2);
      * 
      * result.then(function (value) {
@@ -57,9 +58,11 @@ define(function (require, exports, module) {
      * 
      * @constructor
      * @param {string} domainName Name of the registered Node Domain
-     * @param {string} domainPath Full path of the JavaScript Node domain specification
+     * @param {function} getRemotePort a function that returns the port of the underlying connection
+     * @param {string=} domainPath Optional full path of the JavaScript Node domain specification,
+     *        otherwise a domain of the same name must already registered on the server.
      */
-    function NodeDomain(domainName, domainPath, getRemotePort) {
+    function NodeDomain(domainName, getRemotePort, domainPath) {
         EventEmitter.call(this);
 
         var connection = new NodeConnection(getRemotePort);
@@ -125,7 +128,7 @@ define(function (require, exports, module) {
     NodeDomain.prototype._domainLoaded = false;
     
     /**
-     * Loads the domain via the underlying connection object and exposes the
+     * Validates or loads the domain via the underlying connection object and exposes the
      * domain's commands as methods on this object. Assumes the underlying
      * connection has already been opened.
      * 
@@ -133,16 +136,28 @@ define(function (require, exports, module) {
      * @private
      */
     NodeDomain.prototype._load = function () {
-        var connection = this.connection;
-        return connection.loadDomains(this._domainPath, true)
-            .then(function () {
+        if (!this._domainPath) {
+            // if path not provided, validate that the domain is already loaded into the connection
+            if (!this.connection.domains[this._domainName]) {
+                var reason = "Domain '" + this._domainName + "' does not exist, nor was a domain path provided";
+                return Promise.reject(reason);
+            } else {
                 this._domainLoaded = true;
                 this._connectionPromise = null;
-                this.refreshInterface();
-            }.bind(this))
-            .catch(function (err) {
-                console.error("[NodeDomain] Error loading domain \"" + this._domainName + "\": " + err);
-            }.bind(this));
+                return Promise.resolve();
+            }
+        } else {
+            // Load the domain by path and then request a refresh of interface from the server
+            return this.connection.loadDomains(this._domainPath, true)
+                .then(function () {
+                    this._domainLoaded = true;
+                    this._connectionPromise = null;
+                    this.refreshInterface();
+                }.bind(this))
+                .catch(function (err) {
+                    console.error("[NodeDomain] Error loading domain \"" + this._domainName + "\": " + err);
+                }.bind(this));
+        }
     };
     
     /**


### PR DESCRIPTION
If a domain path is not supplied, then a domain of the same name must have already been registered. Also switched the order of params for clarity, thus bumping to v2.0.