### PR TITLE
Added optional maxConnectionAttempts param, improved error handling

### DIFF
--- a/lib/NodeConnection.js
+++ b/lib/NodeConnection.js
@@ -57,6 +57,7 @@ define(function (require, exports, module) {
      * Helper function to auto-reject a deferred after a given amount of time.
      * If the deferred is resolved/rejected manually, then the timeout is
      * automatically cleared.
+     * // TODO consider using bluebird's `.timeout` instead?
      */
     function setDeferredTimeout(deferred, delay) {
         var timer = setTimeout(function () {
@@ -70,11 +71,13 @@ define(function (require, exports, module) {
      *
      * @constructor
      * @param {function(function (?string, number))} getRemotePort
+     * @param {number=} maxConnectionAttempts maximum number of connection attempts, must be > 0
      */
-    function NodeConnection(getRemotePort) {
+    function NodeConnection(getRemotePort, maxConnectionAttempts) {
         EventEmitter.call(this);
 
         this.getRemotePort = getRemotePort;
+        this._maxConnectionAttempts = maxConnectionAttempts || CONNECTION_ATTEMPTS;
         this.domains = {};
         this._registeredModules = [];
         this._pendingInterfaceRefreshDeferreds = [];
@@ -112,6 +115,13 @@ define(function (require, exports, module) {
      * a disconnection/connection (i.e. if the server died).
      */
     NodeConnection.prototype._registeredModules = null;
+
+    /**
+     * @private
+     * @type {number}
+     * Maximum number of times the connection will be attempted before giving up
+     */
+    NodeConnection.prototype._maxConnectionAttempts = null;
 
     /**
      * @private
@@ -179,41 +189,42 @@ define(function (require, exports, module) {
      * Helper function to attempt a single connection to the node server
      */
     NodeConnection.prototype._attemptSingleConnect = function () {
-        var deferred = Promise.defer();
-        var port = null;
-        var ws = null;
-        setDeferredTimeout(deferred, CONNECTION_TIMEOUT);
+        var getRemotePromised = Promise.promisify(this.getRemotePort, this);
 
-        this.getRemotePort(function (err, nodePort) {
-            if (err) {
-                deferred.reject(err);
-                return;
-            }
+        var _connect = function (nodePort) {
+            return new Promise(function (success, failure) {
+                var port = nodePort;
 
-            port = nodePort;
-            ws = new WebSocket("ws://localhost:" + port);
+                var ws = new WebSocket("ws://localhost:" + port);
 
-            // Expect ArrayBuffer objects from Node when receiving binary
-            // data instead of DOM Blobs, which are the default.
-            ws.binaryType = "arraybuffer";
+                // Expect ArrayBuffer objects from Node when receiving binary
+                // data instead of DOM Blobs, which are the default.
+                ws.binaryType = "arraybuffer";
 
-            // If the server port isn't open, we get a close event
-            // at some point in the future (and will not get an onopen
-            // event)
-            ws.onclose = function () {
-                deferred.reject("WebSocket closed");
-            };
+                // If the server port isn't open, we get a close event
+                // at some point in the future (and will not get an onopen
+                // event)
+                ws.onclose = function () {
+                    ws = null;
+                    failure("WebSocket Closed");
+                };
 
-            ws.onopen = function () {
-                // If we successfully opened, remove the old onclose
-                // handler (which was present to detect failure to
-                // connect at all).
-                ws.onclose = null;
-                deferred.resolve([ws, port]);
-            };
-        });
+                // ws.onerror = function (e) {
+                //     singleAttemptDeferred.reject("Failed to connect to WebSocket: " + e.type);
+                // };
 
-        return deferred.promise;
+                ws.onopen = function () {
+                    // If we successfully opened, remove the old onclose
+                    // handler (which was present to detect failure to
+                    // connect at all).
+                    ws.onclose = null;
+                    //ws.onerror = null;
+                    success({ ws: ws, port: port });
+                };
+            });
+        };
+
+        return getRemotePromised().then(_connect).timeout(CONNECTION_TIMEOUT);
     };
     
     /**
@@ -265,12 +276,16 @@ define(function (require, exports, module) {
         var attemptTimestamp = null;
         
         // Called after a successful connection to do final setup steps
-        function registerHandlersAndDomains(ws, port) {
+        function registerHandlersAndDomains(payload) {
             // Called if we succeed at the final setup
             function success() {
                 self._ws.onclose = function () {
                     if (self._autoReconnect) {
-                        var $promise = self.connect(true);
+                        var $promise = self.connect(true)
+                            .catch(function (e) {
+                                self._cleanup();
+                                throw new Error("Auto reconnect failed: " + e);
+                            });
                         self.emit("close", $promise);
                     } else {
                         self._cleanup();
@@ -285,8 +300,8 @@ define(function (require, exports, module) {
                 deferred.reject(err);
             }
             
-            self._ws = ws;
-            self._port = port;
+            self._ws = payload.ws;
+            self._port = payload.port;
             self._ws.onmessage = self._receive.bind(self);
             
             // refresh the current domains, then re-register any
@@ -312,10 +327,10 @@ define(function (require, exports, module) {
         function doConnect() {
             attemptCount++;
             attemptTimestamp = new Date();
-            self._attemptSingleConnect().spread(
-                registerHandlersAndDomains, // succeded
-                function () { // failed this attempt, possibly try again
-                    if (attemptCount < CONNECTION_ATTEMPTS) { //try again
+            self._attemptSingleConnect()
+                .then(registerHandlersAndDomains) // success
+                .catch(function () { // failed this attempt, possibly try again
+                    if (attemptCount < self._maxConnectionAttempts) { //try again
                         // Calculate how long we should wait before trying again
                         var now = new Date();
                         var delay = Math.max(
@@ -326,8 +341,8 @@ define(function (require, exports, module) {
                     } else { // too many attempts, give up
                         deferred.reject("Max connection attempts reached");
                     }
-                }
-            );
+                    return true;
+                });
         }
         
         // Start the connection process

--- a/lib/NodeConnection.js
+++ b/lib/NodeConnection.js
@@ -189,8 +189,6 @@ define(function (require, exports, module) {
      * Helper function to attempt a single connection to the node server
      */
     NodeConnection.prototype._attemptSingleConnect = function () {
-        var getRemotePromised = Promise.promisify(this.getRemotePort, this);
-
         var _connect = function (nodePort) {
             return new Promise(function (success, failure) {
                 var port = nodePort;
@@ -209,22 +207,19 @@ define(function (require, exports, module) {
                     failure("WebSocket Closed");
                 };
 
-                // ws.onerror = function (e) {
-                //     singleAttemptDeferred.reject("Failed to connect to WebSocket: " + e.type);
-                // };
-
                 ws.onopen = function () {
                     // If we successfully opened, remove the old onclose
                     // handler (which was present to detect failure to
                     // connect at all).
                     ws.onclose = null;
-                    //ws.onerror = null;
                     success({ ws: ws, port: port });
                 };
             });
         };
 
-        return getRemotePromised().then(_connect).timeout(CONNECTION_TIMEOUT);
+        return Promise.promisify(this.getRemotePort, this)()
+            .then(_connect)
+            .timeout(CONNECTION_TIMEOUT);
     };
     
     /**

--- a/lib/NodeDomain.js
+++ b/lib/NodeDomain.js
@@ -170,11 +170,12 @@ define(function (require, exports, module) {
                 .then(function () {
                     this._domainLoaded = true;
                     this._connectionPromise = null;
+                    this.refreshInterface();
                 })
                 .catch(function () {
                     var reason = "Domain '" + this._domainName +
                             "' does not exist, nor was a domain path provided";
-                    return Promise.reject(reason);
+                    return Promise.reject(new Error(reason));
                 });
         } else {
             // Load the domain by path and then request a refresh of interface from the server

--- a/lib/NodeDomain.js
+++ b/lib/NodeDomain.js
@@ -32,6 +32,11 @@ define(function (require, exports, module) {
         EventEmitter = require("eventEmitter");
 
     var NodeConnection = require("./NodeConnection");
+
+    /**
+     * @define{number} Milliseconds to wait before giving up trying to validate existing domain.
+     */
+    var VALIDATE_DOMAIN_TIMEOUT  = 10000; // 10 seconds
     
     /**
      * Provides a simple abstraction for executing the commands of a single
@@ -145,25 +150,32 @@ define(function (require, exports, module) {
             // if path not provided, validate that the domain is already loaded into the connection
             // If it isn't immediately there, wait a bit before trying again
             // Because the websocket starts accepting requests before the domain may have been fully loaded
-            var domainPromise = this.connection.domains[this._domainName] ?
-                Promise.resolve().bind(this) :
-                Promise.delay(2000)
-                    .bind(this)
-                    .then(function () {
-                        if (!this.connection.domains[this._domainName]) {
-                            var reason = "Domain '" + this._domainName +
-                                "' does not exist, nor was a domain path provided";
-                            return Promise.reject(reason);
-                        } else {
-                            console.warn("It took a second try (after delay) to get the domain from the connection");
-                            return Promise.resolve();
-                        }
-                    });
 
-            return domainPromise.then(function () {
-                this._domainLoaded = true;
-                this._connectionPromise = null;
-            });
+            var domainName = this._domainName,
+                connection = this.connection;
+
+            var validateDomainPromise = new Promise(function (resolve) {
+                var validate = function () {
+                    if (connection.domains[domainName]) {
+                        resolve(true);
+                    } else {
+                        setTimeout(validate, 200);
+                    }
+                };
+                validate();
+            }).timeout(VALIDATE_DOMAIN_TIMEOUT);
+
+            return validateDomainPromise
+                .bind(this)
+                .then(function () {
+                    this._domainLoaded = true;
+                    this._connectionPromise = null;
+                })
+                .catch(function () {
+                    var reason = "Domain '" + this._domainName +
+                            "' does not exist, nor was a domain path provided";
+                    return Promise.reject(reason);
+                });
         } else {
             // Load the domain by path and then request a refresh of interface from the server
             return this.connection.loadDomains(this._domainPath, true)

--- a/lib/NodeDomain.js
+++ b/lib/NodeDomain.js
@@ -61,11 +61,12 @@ define(function (require, exports, module) {
      * @param {function} getRemotePort a function that returns the port of the underlying connection
      * @param {string=} domainPath Optional full path of the JavaScript Node domain specification,
      *        otherwise a domain of the same name must already registered on the server.
+     * @param {number=} maxConnectionAttempts Optional limit on number of connection attempts
      */
-    function NodeDomain(domainName, getRemotePort, domainPath) {
+    function NodeDomain(domainName, getRemotePort, domainPath, maxConnectionAttempts) {
         EventEmitter.call(this);
 
-        var connection = new NodeConnection(getRemotePort);
+        var connection = new NodeConnection(getRemotePort, maxConnectionAttempts);
         
         this.connection = connection;
         this._domainName = domainName;
@@ -76,11 +77,15 @@ define(function (require, exports, module) {
             .then(this._load);
 
         var domainPrefix = new RegExp("^" + this._domainName + ":*");
-        connection.on("close", function (promise) {
+        connection.on("close", function (reconnectPromise) {
             this.connection.off(domainPrefix);
             this._domainLoaded = false;
-            if (promise) {
-                this._connectionPromise = promise.then(this._load);
+            if (reconnectPromise) {
+                this._connectionPromise = reconnectPromise
+                    .then(this._load)
+                    .catch(function (e) {
+                        console.error("Received connection close event, but the reconnect also failed: %s", e);
+                    });
             }
         }.bind(this));
     }
@@ -138,14 +143,27 @@ define(function (require, exports, module) {
     NodeDomain.prototype._load = function () {
         if (!this._domainPath) {
             // if path not provided, validate that the domain is already loaded into the connection
-            if (!this.connection.domains[this._domainName]) {
-                var reason = "Domain '" + this._domainName + "' does not exist, nor was a domain path provided";
-                return Promise.reject(reason);
-            } else {
+            // If it isn't immediately there, wait a bit before trying again
+            // Because the websocket starts accepting requests before the domain may have been fully loaded
+            var domainPromise = this.connection.domains[this._domainName] ?
+                Promise.resolve().bind(this) :
+                Promise.delay(2000)
+                    .bind(this)
+                    .then(function () {
+                        if (!this.connection.domains[this._domainName]) {
+                            var reason = "Domain '" + this._domainName +
+                                "' does not exist, nor was a domain path provided";
+                            return Promise.reject(reason);
+                        } else {
+                            console.warn("It took a second try (after delay) to get the domain from the connection");
+                            return Promise.resolve();
+                        }
+                    });
+
+            return domainPromise.then(function () {
                 this._domainLoaded = true;
                 this._connectionPromise = null;
-                return Promise.resolve();
-            }
+            });
         } else {
             // Load the domain by path and then request a refresh of interface from the server
             return this.connection.loadDomains(this._domainPath, true)


### PR DESCRIPTION
Both of the two main constructors now take a new optional argument (maxConnectionAttempts)

To prevent errors from bubbling out when a connection attempts fails (prior to reaching the max allowed attempts), I did some light sprucing up.  I think there may still be an intermittent issue that is causing the NodeConnection to return a resolved connect() promise before the domains are properly initialized.  More work to be done, but this is a step in the right direction.

This does introduce a **fallback** situation with a `.delay(2000)` - which attempts to minimize the above issue, and I hope to remove it in the future as the rest gets tightened up.