### PR TITLE
Added a utility function to help encapsulate the dependency on generator escapePluginId

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,11 +23,30 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*global define */
 
-define(function (require, exports, module) {
+define(function (require, exports) {
     "use strict";
-    
+
+    /**
+     * This helper function will convert a generator domain name into
+     * the key that is used to store its custom preferences in photoshop.
+     *
+     * This assumes that the plugin registered a domain
+     * with the same name as the plugin itself
+     *
+     * The replacement logic must match generator-core
+     * See: generator's escapePluginId() function
+     *
+     * @param {string} domainName
+     * @return {string}
+     */
+    exports.domainPrefKey = function (domainName) {
+        return domainName && domainName.replace(/[^a-zA-Z0-9]/g, function (char) {
+            return "_" + char.charCodeAt(0) + "_";
+        });
+    };
+
     exports.NodeDomain = require("./lib/NodeDomain");
     exports.NodeConnection = require("./lib/NodeConnection");
 });


### PR DESCRIPTION
Some light encoding is performed by generator on plugin *names* in order to safely store their preferences in photoshop.  Since consumers of generator-connection will likely want to fetch those preferences  (eg, the port number), this utility function helps (I think) formalize that soft dependency.  Thoughts @iwehrman?